### PR TITLE
feat: support version pattern matching

### DIFF
--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -17,6 +17,7 @@
 #        with:
 #          path: modules/sentry-cocoa
 #          name: Cocoa SDK
+#          pattern: '^1\.'  # Limit to major version '1'
 #        secrets:
 #          api_token: ${{ secrets.CI_DEPLOY_KEY }}
 #
@@ -48,6 +49,11 @@ on:
         description: Name used for a changelog entry
         type: string
         required: true
+      pattern:
+        description: RegEx pattern that will be matched against available versions when picking the latest one
+        type: string
+        required: false
+        default: ''
       _workflow_version:
         description: 'Internal: specify github-workflows tag to check out scripts from'
         type: string
@@ -108,7 +114,7 @@ jobs:
 
       - name: Update to the latest version
         id: target
-        run: ${{ runner.temp }}/ghwf/scripts/update-dependency.ps1 -Path '${{ inputs.path }}'
+        run: ${{ runner.temp }}/ghwf/scripts/update-dependency.ps1 -Path '${{ inputs.path }}' -Pattern '${{ inputs.pattern }}'
 
       - name: Get the base repo info
         if: steps.target.outputs.latestTag != steps.target.outputs.originalTag

--- a/.github/workflows/workflow-tests.yml
+++ b/.github/workflows/workflow-tests.yml
@@ -10,6 +10,7 @@ jobs:
     with:
       path: tests/sentry-cli.properties
       name: CLI
+      pattern: '^2\.0\.'
       _workflow_version: ${{ github.sha }}
     secrets:
       api_token: ${{ github.token }}

--- a/tests/update-dependency.ps1
+++ b/tests/update-dependency.ps1
@@ -2,9 +2,9 @@ Set-StrictMode -Version latest
 
 . "$PSScriptRoot/common/test-utils.ps1"
 
-function UpdateDependency([Parameter(Mandatory = $true)][string] $path)
+function UpdateDependency([Parameter(Mandatory = $true)][string] $path, [string] $pattern = $null)
 {
-    $result = & "$PSScriptRoot/../scripts/update-dependency.ps1" -Path $path
+    $result = & "$PSScriptRoot/../scripts/update-dependency.ps1" -Path $path -Pattern $pattern
     if (-not $?)
     {
         throw $result
@@ -25,6 +25,14 @@ RunTest "properties-file" {
     @("repo=$repoUrl", "version  =   none") | Out-File $testFile
     UpdateDependency $testFile
     AssertEqual @("repo=$repoUrl", "version  =   $currentVersion") (Get-Content $testFile)
+}
+
+RunTest "version pattern match" {
+    $testFile = "$testDir/test.properties"
+    $repo = 'https://github.com/getsentry/sentry-cli'
+    @("repo=$repo", "version=0") | Out-File $testFile
+    UpdateDependency $testFile '^0\.'
+    AssertEqual @("repo=$repo", "version=0.28.0") (Get-Content $testFile)
 }
 
 RunTest "powershell-script" {


### PR DESCRIPTION
For sentry-react-native update of react-native which also contains tag "latest", but we want a specific version selected.

This feature can also be used to pin to a specific major version, or to avoid pre-releases, if those are tagged in a repository, etc.