### PR TITLE
Add Outputs to Update Workflow

### DIFF
--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -71,13 +71,16 @@ on:
       url:
         description: "The created/updated PRs url."
         value: ${{ jobs.update.outputs.url }}
-      branch_name:
-        description: "The created/updated PRs branch name."
+      baseBranch:
+        description: "The created/updated base branch name."
+        value: ${{ jobs.update.outputs.baseBranch }}
+      prBranch:
+        description: "The created/updated pr branch name."
         value: ${{ jobs.update.outputs.prBranch }}
-      original_tag:
+      originalTag:
         description: "The original tag from which the dependency was updated from."
         value: ${{ jobs.update.outputs.originalTag }}
-      latest_tag:
+      latestTag:
         description: "The latest tag to which the dependency was updated to."
         value: ${{ jobs.update.outputs.latestTag }}
 
@@ -112,9 +115,10 @@ jobs:
     # Map the job outputs to step outputs
     outputs:
       url: ${{ steps.pr.outputs.url }}
-      branch_name: ${{ steps.root.outputs.prBranch }}
-      original_tag: ${{ steps.target.outputs.originalTag }}
-      latest_tag: ${{ steps.target.outputs.latestTag }}
+      baseBranch: ${{ steps.root.outputs.baseBranch }}
+      prBranch: ${{ steps.root.outputs.prBranch }}
+      originalTag: ${{ steps.target.outputs.originalTag }}
+      latestTag: ${{ steps.target.outputs.latestTag }}
     timeout-minutes: 30
     defaults:
       run:

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -68,9 +68,9 @@ on:
       api_token:
         required: true
     outputs:
-      url:
+      prUrl:
         description: "The created/updated PRs url."
-        value: ${{ jobs.update.outputs.url }}
+        value: ${{ jobs.update.outputs.prUrl }}
       baseBranch:
         description: "The base branch name."
         value: ${{ jobs.update.outputs.baseBranch }}
@@ -114,7 +114,7 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     # Map the job outputs to step outputs
     outputs:
-      url: ${{ steps.pr.outputs.url }}
+      prUrl: ${{ steps.pr.outputs.url }}
       baseBranch: ${{ steps.root.outputs.baseBranch }}
       prBranch: ${{ steps.root.outputs.prBranch }}
       originalTag: ${{ steps.target.outputs.originalTag }}

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -70,16 +70,16 @@ on:
     outputs:
       url:
         description: "The created/updated PRs url."
-        value: ${{ jobs.update.steps.pr.outputs.url }}
+        value: ${{ jobs.update.outputs.url }}
       branch_name:
         description: "The created/updated PRs branch name."
-        value: ${{ jobs.update.steps.root.outputs.prBranch }}
+        value: ${{ jobs.update.outputs.prBranch }}
       original_tag:
         description: "The original tag from which the dependency was updated from."
-        value: ${{ jobs.update.steps.target.outputs.originalTag }}
+        value: ${{ jobs.update.outputs.originalTag }}
       latest_tag:
         description: "The latest tag to which the dependency was updated to."
-        value: ${{ jobs.update.steps.target.outputs.latestTag }}
+        value: ${{ jobs.update.outputs.latestTag }}
 
 jobs:
   cancel-previous-run:
@@ -109,6 +109,12 @@ jobs:
   # with notifications about pushes to existing PRs. This way there is actually no push if not needed.
   update:
     runs-on: ${{ inputs.runs-on }}
+    # Map the job outputs to step outputs
+    outputs:
+      url: ${{ steps.pr.outputs.url }}
+      branch_name: ${{ steps.root.outputs.prBranch }}
+      original_tag: ${{ steps.target.outputs.originalTag }}
+      latest_tag: ${{ steps.target.outputs.latestTag }}
     timeout-minutes: 30
     defaults:
       run:

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -72,7 +72,7 @@ on:
         description: "The created/updated PRs url."
         value: ${{ jobs.update.outputs.url }}
       baseBranch:
-        description: "The created/updated base branch name."
+        description: "The base branch name."
         value: ${{ jobs.update.outputs.baseBranch }}
       prBranch:
         description: "The created/updated pr branch name."

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -67,6 +67,19 @@ on:
     secrets:
       api_token:
         required: true
+    outputs:
+      url:
+        description: "The created/updated PRs url."
+        value: ${{ jobs.update.steps.pr.outputs.url }}
+      branch_name:
+        description: "The created/updated PRs branch name."
+        value: ${{ jobs.update.steps.root.outputs.prBranch }}
+      original_tag:
+        description: "The original tag from which the dependency was updated from."
+        value: ${{ jobs.update.steps.target.outputs.originalTag }}
+      latest_tag:
+        description: "The latest tag to which the dependency was updated to."
+        value: ${{ jobs.update.steps.target.outputs.latestTag }}
 
 jobs:
   cancel-previous-run:


### PR DESCRIPTION
This PR adds the following outputs to the update workflow:

- url
- original tag
- latest tag
- base branch
- pr branch

This way, other repositories can pick up the created PR and amend it as they see fit. 

An example can be seen here:

https://github.com/getsentry/sentry-fastlane-plugin/pull/144

The referenced PR takes the created/updated PR, downloads the current sentry-cli macOS & windows binaries and commits them in the PR created by this workflow.
It does not use the `url` and `base branch` outputs, but i left those as they might be useful for other approaches.
