### PR TITLE
fix: show GH annotations when running from forks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 2.1.1
+
+### Fixes
+
+- Show GitHub annotations when running from forks - can't post a PR comment in that case ([#37](https://github.com/getsentry/github-workflows/pull/37))
+
 ## 2.1.0
 
 ### Features

--- a/danger/dangerfile.js
+++ b/danger/dangerfile.js
@@ -9,9 +9,9 @@ if (isFork) {
 
   // Override DangerJS default functions to print to console & create annotations instead.
   const log = function (type, message, file, line) {
-    message = message.replaceAll("%", "%25");
-    message = message.replaceAll("\n", "%0A");
-    message = message.replaceAll("\r", "%0D");
+    message = message.replace(/%/g, "%25");
+    message = message.replace(/\n/g, "%0A");
+    message = message.replace(/\r/g, "%0D");
     console.log(`::${type} file=${file},line=${line}::${message}`);
   };
 


### PR DESCRIPTION
We can't post to the PR in that case.

Also see the PR where I've tested this: #38