### PR TITLE
Add optional java-version input

### DIFF
--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -43,6 +43,10 @@ on:
         type: string
         required: false
         default: v2 # Note: update when publishing a new version
+      java-version:
+        description: Java version that the virtual machine will be set up with.
+        type: string
+        required: false
     secrets:
       api-token:
         required: true
@@ -106,6 +110,13 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ssh-key: ${{ secrets.api-token }}
+
+      - name: 'Set up Java ${{ inputs.java-version }}' 
+        uses: actions/setup-java@v3
+        if: ${{ inputs.java-version != '' }}
+        with:
+          java-version: ${{ inputs.java-version }}
+          distribution: 'temurin'
 
       # In order to run scripts from this repo, we need to check it out manually, doesn't seem available locally.
       - name: Check out workflow scripts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.6.0
+
+- Updater - add option `java-version` input to set up the runner with a certain java version ([#53](https://github.com/getsentry/github-workflows/pull/53))
+
 ## 2.5.1
 
 ### Fixes

--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ jobs:
   Can be either of the following:
   * `create` (default) - create a new PR for new dependency versions as they are released - maintainers may merge or close older PRs manually
   * `update` - keep a single PR that gets updated with new dependency versions until merged - only the latest version update is available at any time
+* `java-version`: Java version that the virtual machine will be set up with.
+  * type: string
+  * required: false
 
 ### Secrets
 


### PR DESCRIPTION
We have our build failing on `main` when trying to update dependencies, because updater does not use java 17 ([logs](https://github.com/getsentry/sentry-java/actions/runs/3730123923/jobs/6326807766)). Looks like default java version for gh runners is 11.

I wanted to just add this action as a step to our workflow file, but turns out it's not possible to use a reusable workflow (updater) as a step, so it has to be added here it seems. Lemme know if there's another way around