### PR TITLE
chore: add "github" to the list of danger action-check whitelist users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.6.0
+## Unreleased
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.6.0
+
+### Features
+
+- Danger - add "github" to the list of whitelisted users for action-pinning check ([#55](https://github.com/getsentry/github-workflows/pull/55))
+
 ## 2.5.1
 
 ### Fixes

--- a/danger/dangerfile.js
+++ b/danger/dangerfile.js
@@ -149,7 +149,7 @@ async function checkActionsArePinned() {
     /^\+? *uses: *(?<user>[^\/]+)\/(?<action>[^@]+)@(?<ref>[^ ]*)/;
   const usesLocalRegex = /^\+? *uses: *\.\//; // e.g. 'uses: ./.github/actions/something'
   const shaRegex = /^[a-f0-9]{40}$/;
-  const whitelistedUsers = ["getsentry", "actions"];
+  const whitelistedUsers = ["getsentry", "actions", "github"];
 
   for (const path of workflowFiles) {
     const diff = await danger.git.structuredDiffForFile(path);


### PR DESCRIPTION
See https://github.com/getsentry/sentry-cocoa/pull/2789