### PR TITLE
fix: updater SSH repos nonbot commits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Updater - non-bot commit checks in PRs for SSH repository URLs (starting with `git@github.com:`) ([#62](https://github.com/getsentry/github-workflows/pull/62))
+
 ### Features
 
 - Sentry-CLI integration test action: support envelopes ([#58](https://github.com/getsentry/github-workflows/pull/58))

--- a/updater/scripts/nonbot-commits.ps1
+++ b/updater/scripts/nonbot-commits.ps1
@@ -6,9 +6,10 @@ param(
 )
 
 Set-StrictMode -Version latest
-$ErrorActionPreference = "Stop"
+$ErrorActionPreference = 'Stop'
 
-$bot = "<noreply@github.com>"
+$RepoUrl = $RepoUrl -replace 'git@github.com:', 'https://github.com/'
+$bot = '<noreply@github.com>'
 
 $tmpDir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid())
 New-Item -ItemType Directory $tmpDir | Out-Null
@@ -29,7 +30,8 @@ try
 
     if ($nonbotCommits.Length -gt 0)
     {
-        Write-Warning "There are commits made by others than $bot"
+`
+            Write-Warning "There are commits made by others than $bot"
     }
     $nonbotCommits
 }

--- a/updater/tests/nonbot-commits.ps1
+++ b/updater/tests/nonbot-commits.ps1
@@ -2,32 +2,34 @@ Set-StrictMode -Version latest
 
 . "$PSScriptRoot/common/test-utils.ps1"
 
-function NonBotCommits([Parameter(Mandatory = $true)][string] $branch)
+foreach ($repoUrl in @('https://github.com/getsentry/github-workflows', 'git@github.com:getsentry/github-workflows.git'))
 {
-    $result = & "$PSScriptRoot/../scripts/nonbot-commits.ps1" `
-        -RepoUrl 'https://github.com/getsentry/github-workflows' -MainBranch 'main' -PrBranch $branch
-    if (-not $?)
+    function NonBotCommits([Parameter(Mandatory = $true)][string] $branch)
     {
-        throw $result
+        $result = & "$PSScriptRoot/../scripts/nonbot-commits.ps1" -RepoUrl $repoUrl -MainBranch 'main' -PrBranch $branch
+        if (-not $?)
+        {
+            throw $result
+        }
+        elseif ($LASTEXITCODE -ne 0)
+        {
+            throw "Script finished with exit code $LASTEXITCODE"
+        }
+        $result
     }
-    elseif ($LASTEXITCODE -ne 0)
-    {
-        throw "Script finished with exit code $LASTEXITCODE"
+
+    RunTest 'empty-if-all-commits-by-bot' {
+        $commits = NonBotCommits 'deps/updater/tests/sentry-cli.properties'
+        AssertEqual '' "$commits"
     }
-    $result
-}
 
-RunTest 'empty-if-all-commits-by-bot' {
-    $commits = NonBotCommits 'deps/updater/tests/sentry-cli.properties'
-    AssertEqual '' "$commits"
-}
+    RunTest 'empty-if-branch-doesnt-exist' {
+        $commits = NonBotCommits 'non-existent-branch'
+        AssertEqual '' "$commits"
+    }
 
-RunTest 'empty-if-branch-doesnt-exist' {
-    $commits = NonBotCommits 'non-existent-branch'
-    AssertEqual '' "$commits"
-}
-
-RunTest 'non-empty-if-changed' {
-    $commits = NonBotCommits 'test/nonbot-commits'
-    AssertEqual '0b7d9cc test: keep this branch' "$commits"
+    RunTest 'non-empty-if-changed' {
+        $commits = NonBotCommits 'test/nonbot-commits'
+        AssertEqual '0b7d9cc test: keep this branch' "$commits"
+    }
 }


### PR DESCRIPTION
fixes: #56 - the issue was with `git@` SSH repo URLs - git doesn't have permissions and failed.

This has gone unnoticed because of pwsh behaviour of ignoring native commands exit code (Hopefully, this will change in the future, see https://github.com/actions/runner-images/issues/8900), `git` in this case. 