### PR TITLE
fix: Danger - recognize PR links based on full URL instead of just the PR number.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Danger - recognize PR links based on full URL instead of just the PR number. ([#68](https://github.com/getsentry/github-workflows/pull/68))
+
 ### Dependencies
 
 - Bump `danger/danger-js` from v11.1.2 to v11.3.1 ([#59](https://github.com/getsentry/github-workflows/pull/59))

--- a/danger/dangerfile.js
+++ b/danger/dangerfile.js
@@ -79,7 +79,7 @@ async function checkChangelog() {
     changelogFile
   );
 
-  const changelogMatch = RegExp(`^(.*?)\n[^\n]+(\(${danger.github.pr.html_url}\)|#${danger.github.pr.number}\\b)`, 's').exec(
+  const changelogMatch = RegExp(`^(.*?)\n[^\n]+(\\(${danger.github.pr.html_url}\\)|#${danger.github.pr.number}\\b)`, 's').exec(
     changelogContents
   );
 

--- a/danger/dangerfile.js
+++ b/danger/dangerfile.js
@@ -79,7 +79,7 @@ async function checkChangelog() {
     changelogFile
   );
 
-  const changelogMatch = RegExp(`^(.*)\n[^\n]+(${danger.github.pr.html_url})`, 's').exec(
+  const changelogMatch = RegExp(`^(.*?)\n[^\n]+(\(${danger.github.pr.html_url}\)|#${danger.github.pr.number}\\b)`, 's').exec(
     changelogContents
   );
 

--- a/danger/dangerfile.js
+++ b/danger/dangerfile.js
@@ -79,7 +79,7 @@ async function checkChangelog() {
     changelogFile
   );
 
-  const changelogMatch = RegExp(`^(.*)\n[^\n]+#${danger.github.pr.number}\\b`, 's').exec(
+  const changelogMatch = RegExp(`^(.*)\n[^\n]+(${danger.github.pr.html_url})`, 's').exec(
     changelogContents
   );
 


### PR DESCRIPTION
This was an issue with there was another link in the changelog that had the same number as the current PR.

Reported by @romtsn on Discord
> e.g. I've opened a new PR with id 643 https://github.com/getsentry/sentry-android-gradle-plugin/blob/fed6ae5645b62abbeea32354b74d623e01b7294c/CHANGELOG.md?plain=1#L10, but there's already an entry #643 which references the sentry-java repo and hence it fails https://github.com/getsentry/sentry-android-gradle-plugin/blob/fed6ae5645b62abbeea32354b74d623e01b7294c/CHANGELOG.md?plain=1#L447