### PR TITLE
chore: remove octokit action dependency

### DIFF
--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -145,27 +145,12 @@ jobs:
               Write-Output "::warning::Target branch '$prBranch' has been changed manually - skipping updater to avoid overwriting these changes."
           }
 
-      - name: Fetch an existing PR
-        if: ${{ ( steps.target.outputs.latestTag != steps.target.outputs.originalTag ) && ( steps.root.outputs.changed == 'false') }}
-        uses: octokit/request-action@89697eb6635e52c6e1e5559f15b5c91ba5100cb0 # v2.1.9
-        id: existing-pr-request
-        with:
-          route: GET /repos/${{ github.repository }}/pulls?base={base}&head={head}
-          head: '${{ github.repository }}:${{ steps.root.outputs.prBranch }}'
-          base: '${{ steps.root.outputs.baseBranch }}'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Parse the existing PR URL
         if: ${{ ( steps.target.outputs.latestTag != steps.target.outputs.originalTag ) && ( steps.root.outputs.changed == 'false') }}
         id: existing-pr
         run: |
-          $data = @'
-          ${{ steps.existing-pr-request.outputs.data }}
-          '@
-
+          $data = gh api repos/${{ github.repository }}/pulls?base=${{ steps.root.outputs.baseBranch }}&head=${{ github.repository }}:${{ steps.root.outputs.prBranch }}
           $prCount = $($data | jq '. | length')
-
           if ($prCount -eq '0')
           {
               "url=" | Tee-Object $env:GITHUB_OUTPUT -Append

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -149,7 +149,7 @@ jobs:
         if: ${{ ( steps.target.outputs.latestTag != steps.target.outputs.originalTag ) && ( steps.root.outputs.changed == 'false') }}
         id: existing-pr
         run: |
-          $data = gh api repos/${{ github.repository }}/pulls?base=${{ steps.root.outputs.baseBranch }}&head=${{ github.repository }}:${{ steps.root.outputs.prBranch }}
+          $data = gh api 'repos/${{ github.repository }}/pulls?base=${{ steps.root.outputs.baseBranch }}&head=${{ steps.root.outputs.prBranch }}'
           $prCount = $($data | jq '. | length')
           if ($prCount -eq '0')
           {

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -151,21 +151,18 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          $data = gh api 'repos/${{ github.repository }}/pulls?base=${{ steps.root.outputs.baseBranch }}&head=${{ steps.root.outputs.prBranch }}'
-          Write-Host $data
-          $prCount = $($data | jq '. | length')
-          if ($prCount -eq '0')
+          $urls = @(gh api 'repos/${{ github.repository }}/pulls?base=${{ steps.root.outputs.baseBranch }}&head=${{ github.repository_owner }}:${{ steps.root.outputs.prBranch }}' --jq '.[].html_url')
+          if ($urls.Length -eq 0)
           {
               "url=" | Tee-Object $env:GITHUB_OUTPUT -Append
           }
-          elseif ($prCount -eq '1')
+          elseif ($urls.Length -eq 1)
           {
-              $url = $($data | Select-String '"html_url": +"(.*/pull/.*)"').Matches[0].Groups[1].Value
-              "url=$url" | Tee-Object $env:GITHUB_OUTPUT -Append
+              "url=$($urls[0])" | Tee-Object $env:GITHUB_OUTPUT -Append
           }
           else
           {
-              throw "Unexpected number of PRs matched: $prCount"
+              throw "Unexpected number of PRs matched ($($urls.Length)): $urls"
           }
 
       - run: git --no-pager diff

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -148,6 +148,8 @@ jobs:
       - name: Parse the existing PR URL
         if: ${{ ( steps.target.outputs.latestTag != steps.target.outputs.originalTag ) && ( steps.root.outputs.changed == 'false') }}
         id: existing-pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           $data = gh api 'repos/${{ github.repository }}/pulls?base=${{ steps.root.outputs.baseBranch }}&head=${{ steps.root.outputs.prBranch }}'
           Write-Host $data

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -150,6 +150,7 @@ jobs:
         id: existing-pr
         run: |
           $data = gh api 'repos/${{ github.repository }}/pulls?base=${{ steps.root.outputs.baseBranch }}&head=${{ steps.root.outputs.prBranch }}'
+          Write-Host $data
           $prCount = $($data | jq '. | length')
           if ($prCount -eq '0')
           {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changes
+
+- Remove `octokit/request-action` dependency in favor of using `gh api` ([#74](https://github.com/getsentry/github-workflows/pull/74))
+
 ### Fixes
 
 - Bump updater action dependency to fix an issue when creating/updating a PR ([#71](https://github.com/getsentry/github-workflows/pull/71))


### PR DESCRIPTION
The octokit action is outdated and the team doesn't seem to maintain it & release the node20 update. https://github.com/octokit/request-action/issues/272

We don't actually need it all that much so let's use `gh` instead.