### PR TITLE
fix: truncate changelog to nearest SemVer even if actual previous version is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Don't update from a manually-updated prerelease to a latest stable release that is earlier than the prerelease ([#78](https://github.com/getsentry/github-workflows/pull/78))
 - Cross-repo links in changelog notes ([#82](https://github.com/getsentry/github-workflows/pull/82))
-- Truncate changelog to the earliest older SemVer even if if the previous version is missing ([#84](https://github.com/getsentry/github-workflows/pull/84))
+- Truncate changelog to nearest SemVer even if actual previous version is missing ([#84](https://github.com/getsentry/github-workflows/pull/84))
 
 ## 2.11.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Don't update from a manually-updated prerelease to a latest stable release that is earlier than the prerelease ([#78](https://github.com/getsentry/github-workflows/pull/78))
 - Cross-repo links in changelog notes ([#82](https://github.com/getsentry/github-workflows/pull/82))
+- Truncate changelog to the earliest older SemVer even if if the previous version is missing ([#84](https://github.com/getsentry/github-workflows/pull/84))
 
 ## 2.11.0
 

--- a/updater/tests/get-changelog.Tests.ps1
+++ b/updater/tests/get-changelog.Tests.ps1
@@ -89,6 +89,25 @@ Features, fixes and improvements in this release have been contributed by:
         $actual | Should -Be $expected
     }
 
+    It 'Does not show versions older than OldTag even if OldTag is missing' {
+        $actual = & "$PSScriptRoot/../scripts/get-changelog.ps1" `
+            -RepoUrl 'https://github.com/getsentry/github-workflows' -OldTag '2.1.5' -NewTag '2.2.1'
+        $actual | Should -Be @'
+## Changelog
+### 2.2.1
+
+#### Fixes
+
+- Support comments when parsing pinned actions in Danger ([#40](https://github-redirect.dependabot.com/getsentry/github-workflows/pull/40))
+
+### 2.2.0
+
+#### Features
+
+- Danger - check for that actions are pinned to a commit ([#39](https://github-redirect.dependabot.com/getsentry/github-workflows/pull/39))
+'@
+    }
+
     It 'truncates too long text' {
         $actual = & "$PSScriptRoot/../scripts/get-changelog.ps1" `
             -RepoUrl 'https://github.com/getsentry/sentry-cli' -OldTag '1.0.0' -NewTag '2.4.0'


### PR DESCRIPTION
Fixes #83