### PR TITLE
fix: gzip compressed envelopes

### DIFF
--- a/sentry-cli/integration-test/sentry-server.py
+++ b/sentry-cli/integration-test/sentry-server.py
@@ -8,6 +8,7 @@ import sys
 import threading
 import binascii
 import json
+import gzip
 
 uri = urlparse(sys.argv[1] if len(sys.argv) > 1 else 'http://127.0.0.1:8000')
 apiOrg = 'org'
@@ -135,6 +136,8 @@ class Handler(BaseHTTPRequestHandler):
         if self.command == "POST" and 'Content-Length' in self.headers:
             length = int(self.headers['Content-Length'])
             content = self.rfile.read(length)
+            if self.headers.get("Content-Encoding") == "gzip":
+                content = gzip.decompress(content)
             try:
                 return content.decode("utf-8")
             except:


### PR DESCRIPTION
The problem was originally noticed while experimenting with replacing sentry-native's curl transport with a .NET implementation for sentry-dotnet:

- https://github.com/getsentry/sentry-dotnet/pull/4222

The problem is also easy to reproduce by simply building sentry-native with `SENTRY_TRANSPORT_COMPRESSION=ON`, which results in:
```
Server stdout:
HTTP server listening on http://127.0.0.1:8000
To stop the server, execute a GET request to http://127.0.0.1:8000/STOP
POST /api/0/envelope/ HTTP/1.1
     envelope start
GET /STOP HTTP/1.1
HTTP server stopping!

Server stderr:
----------------------------------------
Exception occurred during processing of request from ('127.0.0.1', 55668)
Traceback (most recent call last):
  File "/usr/lib/python3.12/socketserver.py", line 692, in process_request_thread
    self.finish_request(request, client_address)
  File "/usr/lib/python3.12/socketserver.py", line 362, in finish_request
    self.RequestHandlerClass(request, client_address, self)
  File "/usr/lib/python3.12/socketserver.py", line 761, in __init__
    self.handle()
  File "/usr/lib/python3.12/http/server.py", line 436, in handle
    self.handle_one_request()
  File "/usr/lib/python3.12/http/server.py", line 424, in handle_one_request
    method()
  File "/home/jpnurmi/Projects/sentry/github-workflows/sentry-cli/integration-test/sentry-server.py", line 97, in do_POST
    sys.stdout.write(self.body)
TypeError: write() argument must be str, not bytes
----------------------------------------

[-] Console app NativeAOT (net8.0).Produces the expected exception (Native) 1.81s (1.81s|1ms)
 Expected $false, but got $true.
 at $result.HasErrors() | Should -BeFalse, /home/jpnurmi/Projects/sentry/sentry-dotnet/integration-test/runtime.Tests.ps1:172
 at <ScriptBlock>, /home/jpnurmi/Projects/sentry/sentry-dotnet/integration-test/runtime.Tests.ps1:172
```