### PR TITLE
chore: Update get-changelog.Tests.ps1

### DIFF
--- a/updater/tests/get-changelog.Tests.ps1
+++ b/updater/tests/get-changelog.Tests.ps1
@@ -134,7 +134,7 @@ Features, fixes and improvements in this release have been contributed by:
 
 - Add support for Xbox Series X/S. ([#1100](https://github-redirect.dependabot.com/getsentry/sentry-native/pull/1100))
 - Add option to set debug log level. ([#1107](https://github-redirect.dependabot.com/getsentry/sentry-native/pull/1107))
-- Add `traces_sampler` ([#1108](https://github-redirect.dependabot.com/getsentry/sentry-native/pull/1108))
+- Add `traces_sampler`. ([#1108](https://github-redirect.dependabot.com/getsentry/sentry-native/pull/1108))
 - Provide support for C++17 compilers when using the `crashpad` backend. ([#1110](https://github-redirect.dependabot.com/getsentry/sentry-native/pull/1110), [crashpad#116](https://github-redirect.dependabot.com/getsentry/crashpad/pull/116), [mini_chromium#1](https://github-redirect.dependabot.com/getsentry/mini_chromium/pull/1))
 '@
 


### PR DESCRIPTION
This got broken by [an unlucky change](https://github.com/getsentry/sentry-native/commit/4ebdbe900a085c0a97f8ef52edeeef04bf715da6#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR43) in an old sentry-native changelog item we rely on in our tests...

#skip-changelog