### PR TITLE
feat(danger): Allow skipping changelog with label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 2.13.0
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Danger - Changelog checks can now additionally be skipped with a `skip-changelog` label ([#94](https://github.com/getsentry/github-workflows/pull/94))
+
 ## 2.12.0
 
 ### Features

--- a/danger/dangerfile.js
+++ b/danger/dangerfile.js
@@ -70,7 +70,7 @@ async function checkChangelog() {
   if (
     ["ci", "test", "deps", "chore(deps)", "build(deps)"].includes(prFlavor) ||
     (danger.github.pr.body + "").includes("#skip-changelog") ||
-    (pr.labels || []).some(label => label.name === 'skip-changelog')
+    (danger.github.pr.labels || []).some(label => label.name === 'skip-changelog')
   ) {
     return;
   }

--- a/danger/dangerfile.js
+++ b/danger/dangerfile.js
@@ -69,7 +69,8 @@ async function checkChangelog() {
   // Check if skipped
   if (
     ["ci", "test", "deps", "chore(deps)", "build(deps)"].includes(prFlavor) ||
-    (danger.github.pr.body + "").includes("#skip-changelog")
+    (danger.github.pr.body + "").includes("#skip-changelog") ||
+    (pr.labels || []).some(label => label.name === 'skip-changelog')
   ) {
     return;
   }
@@ -126,7 +127,7 @@ Example:
 - ${prTitleFormatted} ([#${danger.github.pr.number}](${danger.github.pr.html_url}))
 \`\`\`
 
-If none of the above apply, you can opt out of this check by adding \`#skip-changelog\` to the PR description.`.trim(),
+If none of the above apply, you can opt out of this check by adding \`#skip-changelog\` to the PR description or adding a \`skip-changelog\` label.`.trim(),
     changelogFile
   );
 }


### PR DESCRIPTION
This allows skipping the danger changelog check with a `skip-changelog` label in addition to `#skip-changelog` in the PR description.

To make sure this triggers properly, the `danger` workflow should be run on a PR being `labeled` and `unlabeled`.

Closes #93.

Please feel free to close this if this functionality isn't desired.