### PR TITLE
fix(readme): Adjust danger template for #94

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ name: Danger
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, edited, ready_for_review]
+    types: [opened, synchronize, reopened, edited, ready_for_review, labeled, unlabeled]
 
 jobs:
   danger:


### PR DESCRIPTION
The example should mention `labeled` and `unlabeled`.

#skip-changelog