### PR TITLE
Feat(sentry-server): Add Proguard artifact endpoint for Android builds

### DIFF
--- a/sentry-cli/integration-test/sentry-server.py
+++ b/sentry-cli/integration-test/sentry-server.py
@@ -93,6 +93,8 @@ class Handler(BaseHTTPRequestHandler):
             self.writeJSON('{ }')
         elif self.isApi('api/0/organizations/{}/chunk-upload/'.format(apiOrg)):
             self.writeJSON('{ }')
+        elif self.isApi('/api/0/projects/{}/{}/files/proguard-artifact-releases/'.format(apiOrg, apiProject)):
+            self.writeJSON('{ }')
         elif self.isApi('api/0/envelope'):
             sys.stdout.write("     envelope start\n")
             sys.stdout.write(self.body)


### PR DESCRIPTION
Fixes #99

# Problem

In other integration test servers, they have endpoints for `proguard-artifact-releases`:
- https://github.com/getsentry/sentry-maven-plugin/blob/c2403b7113af5351d732308b24b2016dba0a4714/test/integration-test-server.py#L45
- https://github.com/getsentry/sentry-android-gradle-plugin/blob/5e15a33821ffe42aaa86a2a9311738f01a943820/test/integration-test-server.py#L45

This is causing [getsentry/sentry-dotnet #4532](https://github.com/getsentry/sentry-dotnet/pull/4532) to fail.

# Solution

Create an endpoint in `sentry-server.py` for proguard artifact upload
