### PR TITLE
chore: add minimal Craft release tooling configuration

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -1,0 +1,5 @@
+minVersion: 0.23.1
+changelogPolicy: auto
+preReleaseCommand: pwsh -c ''
+targets:
+  - name: github

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version to release
+        required: true
+      force:
+        description: Force a release even when there are release-blockers (optional)
+        required: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    name: "Release a new version"
+    steps:
+      - name: Get auth token
+        id: token
+        uses: actions/create-github-app-token@5d869da34e18e7287c1daad50e0b8ea0f506ce69 # v1.11.0
+        with:
+          app-id: ${{ vars.SENTRY_RELEASE_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.SENTRY_RELEASE_BOT_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ steps.token.outputs.token }}
+          fetch-depth: 0
+
+      - name: Prepare release
+        uses: getsentry/action-prepare-release@v1
+        env:
+          GITHUB_TOKEN: ${{ steps.token.outputs.token }}
+        with:
+          version: ${{ github.event.inputs.version }}
+          force: ${{ github.event.inputs.force }}


### PR DESCRIPTION
## Summary
- Add minimal .craft.yml configuration for automated GitHub releases
- Add release workflow with required version input

## Details
This adds basic Craft release tooling to enable automated release management:

### Craft Configuration (.craft.yml)
- Uses same minVersion (0.23.1) and auto changelog policy as other Sentry repos
- GitHub-only releases - no artifact publishing needed
- **preReleaseCommand**: `pwsh -c ''` (no-op command that always succeeds)
- No actual version tracking or file updates needed

### Release Workflow (.github/workflows/release.yml)
- Manual workflow_dispatch trigger with **required** version input
- No auto-version generation - user must provide version manually
- Uses getsentry/action-prepare-release@v1 to handle release preparation
- Authenticates with Sentry release bot credentials
- Simple and minimal compared to console SDK workflows

### Key Differences from Console SDKs
- **No VERSION file**: No version tracking in repository
- **No scripts**: No version bump or generation scripts needed
- **Required input**: Version must always be provided manually
- **No-op preRelease**: Command does nothing but succeed

This enables the github-workflows repository to use the standard Sentry release process while keeping the implementation minimal.

#skip-changelog

🤖 Generated with [Claude Code](https://claude.ai/code)