### PR TITLE
test: Add proguard endpoint in sentry-server test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Add Proguard artifact endpoint for Android builds in sentry-server ([#100](https://github.com/getsentry/github-workflows/pull/100))
+- Add proguard endpoint in sentry-server test ([#102](https://github.com/getsentry/github-workflows/pull/102))
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 ### Features
 
 - Add Proguard artifact endpoint for Android builds in sentry-server ([#100](https://github.com/getsentry/github-workflows/pull/100))
-- Add proguard endpoint in sentry-server test ([#102](https://github.com/getsentry/github-workflows/pull/102))
 
 ### Security
 

--- a/sentry-cli/integration-test/tests/action.Tests.ps1
+++ b/sentry-cli/integration-test/tests/action.Tests.ps1
@@ -47,6 +47,7 @@ Describe 'Invoke-SentryServer' {
         $result = Invoke-SentryServer {
             Param([string]$url)
             Invoke-WebRequest -Uri "$url/api/0/projects/org/project/files/dsyms/associate/" -Method Post
+            Invoke-WebRequest -Uri "$url/api/0/projects/org/project/files/proguard-artifact-releases" -Method Post
         }
         Should -ActualValue $result.HasErrors() -BeFalse
     }


### PR DESCRIPTION
There was a section for the proguard mapping test already, so I added the proguard endpoint to that test. Not sure if it's good enough 🤔 