### PR TITLE
chore: add artifactProvider configuration to craft

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -1,5 +1,7 @@
 minVersion: 0.23.1
 changelogPolicy: auto
 preReleaseCommand: pwsh -cwa ''
+artifactProvider:
+  name: none
 targets:
   - name: github


### PR DESCRIPTION
## Summary
Add `artifactProvider: name: none` configuration to .craft.yml

## Details
This update specifies that the github-workflows repository doesn't need artifact publishing as part of its release process.

### Changes
- **artifactProvider**: Set to `none` since this repository doesn't publish artifacts to package managers
- Simplifies the release process to focus only on GitHub releases
- Follows the same pattern as console SDK repositories

### Why This Change
The artifact provider configuration explicitly tells craft that no artifact publishing step is needed, which is appropriate for a repository containing reusable GitHub workflows rather than distributable packages.

#skip-changelog

🤖 Generated with [Claude Code](https://claude.ai/code)