### PR TITLE
fix: Remove workflow file updates from Craft release automation

### DIFF
--- a/scripts/update-version.ps1
+++ b/scripts/update-version.ps1
@@ -12,33 +12,19 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 $PSNativeCommandUseErrorActionPreference = $true
 
-Write-Host "Updating version from $OldVersion to $NewVersion"
+Write-Host "Preparing release version update from $OldVersion to $NewVersion"
 
-# Update specific workflow files with _workflow_version inputs
-Write-Host "Updating workflow files..."
-$workflowFiles = @(
-    ".github/workflows/updater.yml",
-    ".github/workflows/danger.yml"
-)
+# Note: Workflow files cannot be updated automatically during Craft releases
+# because GitHub Apps don't have 'workflows' permission by default.
+#
+# After this release is published, manually update the following files:
+# - .github/workflows/updater.yml (line ~45)
+# - .github/workflows/danger.yml (line ~9)
+#
+# Change the default value from '$OldVersion' to '$NewVersion'
 
-foreach ($filePath in $workflowFiles) {
-    $content = Get-Content -Path $filePath -Raw
-
-    # Check if this file has _workflow_version input with a default value
-    if ($content -match '(?ms)_workflow_version:.*?default:\s*([^\s#]+)') {
-        Write-Host "Updating $filePath..."
-        $oldDefault = $Matches[1]
-
-        # Replace the default value for _workflow_version
-        $newContent = $content -replace '((?ms)_workflow_version:.*?default:\s*)([^\s#]+)', "`${1}'$NewVersion'"
-
-        # Write the updated content back to the file
-        $newContent | Out-File -FilePath $filePath -Encoding utf8 -NoNewline
-
-        Write-Host "  Updated default from '$oldDefault' to '$NewVersion'"
-    } else {
-        Write-Error "No _workflow_version default found in $filePath"
-    }
-}
-
-Write-Host "Version update completed successfully!"
+Write-Host ""
+Write-Host "⚠️  MANUAL ACTION REQUIRED AFTER RELEASE:"
+Write-Host "Update _workflow_version defaults in workflow files from '$OldVersion' to '$NewVersion'"
+Write-Host ""
+Write-Host "Release preparation completed successfully!"


### PR DESCRIPTION
## Summary
Fixes the Craft release failure by removing automatic workflow file updates that require GitHub App `workflows` permission.

## Problem
The Craft release process failed with this error:
```
refusing to allow a GitHub App to create or update workflow `.github/workflows/danger.yml` without `workflows` permission
```

This happened because our PowerShell script tried to automatically update `_workflow_version` defaults in workflow files during the release, but GitHub Apps don't have `workflows` permission by default.

## Solution
- **Removes automatic workflow file updates** from the PowerShell script
- **Provides clear manual instructions** for updating `_workflow_version` defaults after release
- **Maintains the script structure** for potential future use with proper permissions

## Changes
- Modified `scripts/update-version.ps1` to only display instructions instead of modifying workflow files
- Script now outputs clear manual action required message
- Prevents Craft release failures due to insufficient permissions

## Manual Process
After each release is published, manually update:
- `.github/workflows/updater.yml` (line ~45)
- `.github/workflows/danger.yml` (line ~9)

Change the `default` value from the old version to the new version.

## Test plan
- [x] Test script runs without errors
- [x] Verify script provides clear instructions
- [ ] Test Craft release process completes successfully

🤖 Generated with [Claude Code](https://claude.ai/code)