### PR TITLE
Convert workflow test scripts to use PowerShell and Pester

### DIFF
--- a/.github/workflows/danger-workflow-tests.yml
+++ b/.github/workflows/danger-workflow-tests.yml
@@ -30,7 +30,6 @@ jobs:
           Write-Host "Danger Outcome: '$env:DANGER_OUTCOME'"
 
           # Validate that Danger ran successfully
-          # T
           $env:DANGER_OUTCOME | Should -Be "success"
 
           Write-Host "✅ Danger PR analysis completed successfully!"

--- a/.github/workflows/danger-workflow-tests.yml
+++ b/.github/workflows/danger-workflow-tests.yml
@@ -24,19 +24,14 @@ jobs:
       - name: Validate danger outputs
         env:
           DANGER_OUTCOME: ${{ steps.danger.outputs.outcome }}
+        shell: pwsh
         run: |
-          echo "🔍 Validating Danger action outputs..."
-          echo "Danger Outcome: '$DANGER_OUTCOME'"
+          Write-Host "🔍 Validating Danger action outputs..."
+          Write-Host "Danger Outcome: '$env:DANGER_OUTCOME'"
 
           # Validate that Danger ran successfully
-          if [[ "$DANGER_OUTCOME" != "success" ]]; then
-            echo "❌ Expected Danger outcome 'success', got '$DANGER_OUTCOME'"
-            echo "This could indicate:"
-            echo "  - Danger found issues that caused it to fail"
-            echo "  - The action itself encountered an error"
-            echo "  - Docker container issues"
-            exit 1
-          fi
+          # T
+          $env:DANGER_OUTCOME | Should -Be "success"
 
-          echo "✅ Danger PR analysis completed successfully!"
-          echo "ℹ️  Check the PR comments for any Danger findings"
+          Write-Host "✅ Danger PR analysis completed successfully!"
+          Write-Host "ℹ️  Check the PR comments for any Danger findings"

--- a/.github/workflows/workflow-tests.yml
+++ b/.github/workflows/workflow-tests.yml
@@ -33,45 +33,31 @@ jobs:
           LATEST_TAG: ${{ steps.updater.outputs.latestTag }}
           PR_URL: ${{ steps.updater.outputs.prUrl }}
           PR_BRANCH: ${{ steps.updater.outputs.prBranch }}
+        shell: pwsh
         run: |
-          echo "🔍 Validating PR creation scenario outputs..."
-          echo "Base Branch: '$BASE_BRANCH'"
-          echo "Original Tag: '$ORIGINAL_TAG'"
-          echo "Latest Tag: '$LATEST_TAG'"
-          echo "PR URL: '$PR_URL'"
-          echo "PR Branch: '$PR_BRANCH'"
+          Write-Host "🔍 Validating PR creation scenario outputs..."
+          Write-Host "Base Branch: '$env:BASE_BRANCH'"
+          Write-Host "Original Tag: '$env:ORIGINAL_TAG'"
+          Write-Host "Latest Tag: '$env:LATEST_TAG'"
+          Write-Host "PR URL: '$env:PR_URL'"
+          Write-Host "PR Branch: '$env:PR_BRANCH'"
 
           # Validate base branch is main
-          if [[ "$BASE_BRANCH" != "main" ]]; then
-            echo "❌ Expected base branch 'main', got '$BASE_BRANCH'"
-            exit 1
-          fi
+          $env:BASE_BRANCH | Should -Be "main"
 
           # Validate original tag is expected test value
-          if [[ "$ORIGINAL_TAG" != "2.0.0" ]]; then
-            echo "❌ Expected original tag '2.0.0', got '$ORIGINAL_TAG'"
-            exit 1
-          fi
+          $env:ORIGINAL_TAG | Should -Be "2.0.0"
 
           # Validate latest tag is a valid version
-          if [[ ! "$LATEST_TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "❌ Latest tag '$LATEST_TAG' is not a valid version format"
-            exit 1
-          fi
+          $env:LATEST_TAG | Should -Match "^[0-9]+\.[0-9]+\.[0-9]+$"
 
           # Validate PR URL format
-          if [[ ! "$PR_URL" =~ ^https://github\.com/getsentry/github-workflows/pull/[0-9]+$ ]]; then
-            echo "❌ PR URL '$PR_URL' is not a valid GitHub PR URL"
-            exit 1
-          fi
+          $env:PR_URL | Should -Match "^https://github\.com/getsentry/github-workflows/pull/[0-9]+$"
 
           # Validate PR branch format
-          if [[ "$PR_BRANCH" != "deps/updater/tests/sentry-cli.properties" ]]; then
-            echo "❌ Expected PR branch 'deps/updater/tests/sentry-cli.properties', got '$PR_BRANCH'"
-            exit 1
-          fi
+          $env:PR_BRANCH | Should -Be "deps/updater/tests/sentry-cli.properties"
 
-          echo "✅ PR creation scenario validation passed!"
+          Write-Host "✅ PR creation scenario validation passed!"
 
   # Test target-branch functionality - should use specified branch as base
   updater-target-branch:
@@ -97,45 +83,31 @@ jobs:
           LATEST_TAG: ${{ steps.updater.outputs.latestTag }}
           PR_URL: ${{ steps.updater.outputs.prUrl }}
           PR_BRANCH: ${{ steps.updater.outputs.prBranch }}
+        shell: pwsh
         run: |
-          echo "🔍 Validating target-branch scenario outputs..."
-          echo "Base Branch: '$BASE_BRANCH'"
-          echo "Original Tag: '$ORIGINAL_TAG'"
-          echo "Latest Tag: '$LATEST_TAG'"
-          echo "PR URL: '$PR_URL'"
-          echo "PR Branch: '$PR_BRANCH'"
+          Write-Host "🔍 Validating target-branch scenario outputs..."
+          Write-Host "Base Branch: '$env:BASE_BRANCH'"
+          Write-Host "Original Tag: '$env:ORIGINAL_TAG'"
+          Write-Host "Latest Tag: '$env:LATEST_TAG'"
+          Write-Host "PR URL: '$env:PR_URL'"
+          Write-Host "PR Branch: '$env:PR_BRANCH'"
 
           # Validate base branch is the specified target-branch
-          if [[ "$BASE_BRANCH" != "test/nonbot-commits" ]]; then
-            echo "❌ Expected base branch 'test/nonbot-commits', got '$BASE_BRANCH'"
-            exit 1
-          fi
+          $env:BASE_BRANCH | Should -Be "test/nonbot-commits"
 
           # Validate original tag is expected test value
-          if [[ "$ORIGINAL_TAG" != "2.0.0" ]]; then
-            echo "❌ Expected original tag '2.0.0', got '$ORIGINAL_TAG'"
-            exit 1
-          fi
+          $env:ORIGINAL_TAG | Should -Be "2.0.0"
 
           # Validate latest tag is a valid version
-          if [[ ! "$LATEST_TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "❌ Latest tag '$LATEST_TAG' is not a valid version format"
-            exit 1
-          fi
+          $env:LATEST_TAG | Should -Match "^[0-9]+\.[0-9]+\.[0-9]+$"
 
           # Validate PR URL format
-          if [[ ! "$PR_URL" =~ ^https://github\.com/getsentry/github-workflows/pull/[0-9]+$ ]]; then
-            echo "❌ PR URL '$PR_URL' is not a valid GitHub PR URL"
-            exit 1
-          fi
+          $env:PR_URL | Should -Match "^https://github\.com/getsentry/github-workflows/pull/[0-9]+$"
 
           # Validate PR branch format
-          if [[ "$PR_BRANCH" != "test/nonbot-commits-deps/updater/tests/sentry-cli.properties" ]]; then
-            echo "❌ Expected PR branch 'test/nonbot-commits-deps/updater/tests/sentry-cli.properties', got '$PR_BRANCH'"
-            exit 1
-          fi
+          $env:PR_BRANCH | Should -Be "test/nonbot-commits-deps/updater/tests/sentry-cli.properties"
 
-          echo "✅ Target-branch scenario validation passed!"
+          Write-Host "✅ Target-branch scenario validation passed!"
 
   # Test no-change scenario - should detect no updates needed
   updater-no-changes:
@@ -159,43 +131,31 @@ jobs:
           LATEST_TAG: ${{ steps.updater.outputs.latestTag }}
           PR_URL: ${{ steps.updater.outputs.prUrl }}
           PR_BRANCH: ${{ steps.updater.outputs.prBranch }}
+        shell: pwsh
         run: |
-          echo "🔍 Validating no-changes scenario outputs..."
-          echo "Base Branch: '$BASE_BRANCH'"
-          echo "Original Tag: '$ORIGINAL_TAG'"
-          echo "Latest Tag: '$LATEST_TAG'"
-          echo "PR URL: '$PR_URL'"
-          echo "PR Branch: '$PR_BRANCH'"
+          Write-Host "🔍 Validating no-changes scenario outputs..."
+          Write-Host "Base Branch: '$env:BASE_BRANCH'"
+          Write-Host "Original Tag: '$env:ORIGINAL_TAG'"
+          Write-Host "Latest Tag: '$env:LATEST_TAG'"
+          Write-Host "PR URL: '$env:PR_URL'"
+          Write-Host "PR Branch: '$env:PR_BRANCH'"
 
           # Validate no PR was created (empty values)
-          if [[ -n "$BASE_BRANCH" ]]; then
-            echo "❌ Expected empty base branch for no-changes, got '$BASE_BRANCH'"
-            exit 1
-          fi
+          $env:BASE_BRANCH | Should -BeNullOrEmpty
 
-          if [[ -n "$PR_URL" ]]; then
-            echo "❌ Expected no PR URL for no-changes, got '$PR_URL'"
-            exit 1
-          fi
+          $env:PR_URL | Should -BeNullOrEmpty
 
-          if [[ -n "$PR_BRANCH" ]]; then
-            echo "❌ Expected no PR branch for no-changes, got '$PR_BRANCH'"
-            exit 1
-          fi
+          $env:PR_BRANCH | Should -BeNullOrEmpty
 
           # Validate original equals latest (no update)
-          if [[ "$ORIGINAL_TAG" != "$LATEST_TAG" ]]; then
-            echo "❌ Expected original tag to equal latest tag, got '$ORIGINAL_TAG' != '$LATEST_TAG'"
-            exit 1
-          fi
+          $env:ORIGINAL_TAG | Should -Be $env:LATEST_TAG
 
           # Validate tag format (should be 'latest' or valid version)
-          if [[ "$ORIGINAL_TAG" != "latest" && ! "$ORIGINAL_TAG" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "❌ Original tag '$ORIGINAL_TAG' is not 'latest' or valid version format"
-            exit 1
-          fi
+          if ($env:ORIGINAL_TAG -ne "latest") {
+            $env:ORIGINAL_TAG | Should -Match "^v?[0-9]+\.[0-9]+\.[0-9]+$"
+          }
 
-          echo "✅ No-changes scenario validation passed!"
+          Write-Host "✅ No-changes scenario validation passed!"
 
   cli-integration:
     runs-on: ${{ matrix.host }}-latest


### PR DESCRIPTION
## Summary
- Converted bash conditionals to Pester Should assertions in workflow test files
- Changed shell from `bash` to `pwsh` for all validation steps  
- Updated environment variable syntax from `$VAR` to `$env:VAR`
- Replaced `echo` with `Write-Host` for PowerShell compatibility
- Simplified test logic using Pester's built-in assertion methods

## Test plan
- [x] Verified syntax changes are correct for PowerShell
- [x] Confirmed Pester assertions match original bash logic
- [ ] Run workflow tests in CI to validate functionality

The tests now use cleaner Pester syntax like:
- `$env:BASE_BRANCH | Should -Be "main"` instead of bash conditionals
- `$env:LATEST_TAG | Should -Match "^[0-9]+\.[0-9]+\.[0-9]+$"` for regex matching
- `$env:PR_URL | Should -BeNullOrEmpty` for empty value checks

🤖 Generated with [Claude Code](https://claude.ai/code)