### PR TITLE
feat!: Change updater pr-strategy default to 'update'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Breaking Changes
 
-- Updater: The default value for `pr-strategy` has been changed from `create` to `update`.
+- Updater: The default value for `pr-strategy` has been changed from `create` to `update`. ([#124](https://github.com/getsentry/github-workflows/pull/124))
   This change means the updater will now maintain a single PR that gets updated with new dependency versions (instead of creating separate PRs for each version).
   If you want to preserve the previous behavior of creating separate PRs, explicitly set `pr-strategy: create` in your workflow:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@
 
 ### Breaking Changes
 
+Updater: The default value for `pr-strategy` has been changed from `create` to `update`.
+
+This change means the updater will now maintain a single PR that gets updated with new dependency versions (instead of creating separate PRs for each version).
+
+If you want to preserve the previous behavior of creating separate PRs, explicitly set `pr-strategy: create` in your workflow:
+
+```yaml
+- uses: getsentry/github-workflows/updater@v3
+  with:
+    # ... other inputs ...
+    pr-strategy: create  # Add this to preserve previous behavior
+```
+
 Updater and Danger reusable workflows are now composite actions ([#114](https://github.com/getsentry/github-workflows/pull/114))
 
 To update your existing Updater workflows:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,56 +4,57 @@
 
 ### Breaking Changes
 
-Updater: The default value for `pr-strategy` has been changed from `create` to `update`.
+- Updater: The default value for `pr-strategy` has been changed from `create` to `update`.
+  This change means the updater will now maintain a single PR that gets updated with new dependency versions (instead of creating separate PRs for each version).
+  If you want to preserve the previous behavior of creating separate PRs, explicitly set `pr-strategy: create` in your workflow:
 
-This change means the updater will now maintain a single PR that gets updated with new dependency versions (instead of creating separate PRs for each version).
-
-If you want to preserve the previous behavior of creating separate PRs, explicitly set `pr-strategy: create` in your workflow:
-
-```yaml
-- uses: getsentry/github-workflows/updater@v3
-  with:
-    # ... other inputs ...
-    pr-strategy: create  # Add this to preserve previous behavior
-```
-
-Updater and Danger reusable workflows are now composite actions ([#114](https://github.com/getsentry/github-workflows/pull/114))
-
-To update your existing Updater workflows:
-```yaml
-### Before
-  native:
-    uses: getsentry/github-workflows/.github/workflows/updater.yml@v2
+  ```yaml
+  - uses: getsentry/github-workflows/updater@v3
     with:
-      path: scripts/update-sentry-native-ndk.sh
-      name: Native SDK
-    secrets:
-      # If a custom token is used instead, a CI would be triggered on a created PR.
-      api-token: ${{ secrets.CI_DEPLOY_KEY }}
+      # ... other inputs ...
+      pr-strategy: create  # Add this to preserve previous behavior
+  ```
 
-### After
-  native:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: getsentry/github-workflows/updater@v3
-        with:
-          path: scripts/update-sentry-native-ndk.sh
-          name: Native SDK
-          api-token: ${{ secrets.CI_DEPLOY_KEY }}
-```
+  In case you have existing open PRs created with the `create` strategy, you will need to remove these old branches
+  manually as the new name would be a prefix of the old PRs, which git doesnt' allow.
 
-To update your existing Danger workflows:
-```yaml
-### Before
-  danger:
-    uses: getsentry/github-workflows/.github/workflows/danger.yml@v2
+- Updater and Danger reusable workflows are now composite actions ([#114](https://github.com/getsentry/github-workflows/pull/114))
 
-### After
-  danger:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: getsentry/github-workflows/danger@v3
-```
+  To update your existing Updater workflows:
+  ```yaml
+  ### Before
+    native:
+      uses: getsentry/github-workflows/.github/workflows/updater.yml@v2
+      with:
+        path: scripts/update-sentry-native-ndk.sh
+        name: Native SDK
+      secrets:
+        # If a custom token is used instead, a CI would be triggered on a created PR.
+        api-token: ${{ secrets.CI_DEPLOY_KEY }}
+
+  ### After
+    native:
+      runs-on: ubuntu-latest
+      steps:
+        - uses: getsentry/github-workflows/updater@v3
+          with:
+            path: scripts/update-sentry-native-ndk.sh
+            name: Native SDK
+            api-token: ${{ secrets.CI_DEPLOY_KEY }}
+  ```
+
+  To update your existing Danger workflows:
+  ```yaml
+  ### Before
+    danger:
+      uses: getsentry/github-workflows/.github/workflows/danger.yml@v2
+
+  ### After
+    danger:
+      runs-on: ubuntu-latest
+      steps:
+        - uses: getsentry/github-workflows/danger@v3
+  ```
 
 ### Features
 

--- a/updater/README.md
+++ b/updater/README.md
@@ -129,8 +129,8 @@ jobs:
   * default: Dependencies
 * `pr-strategy`: How to handle PRs.
   Can be either of the following:
-  * `create` (default) - create a new PR for new dependency versions as they are released - maintainers may merge or close older PRs manually
-  * `update` - keep a single PR that gets updated with new dependency versions until merged - only the latest version update is available at any time
+  * `create` - create a new PR for new dependency versions as they are released - maintainers may merge or close older PRs manually
+  * `update` (default) - keep a single PR that gets updated with new dependency versions until merged - only the latest version update is available at any time
 * `target-branch`: Branch to use as base for dependency updates. Defaults to repository default branch if not specified.
   * type: string
   * required: false

--- a/updater/action.yml
+++ b/updater/action.yml
@@ -28,7 +28,7 @@ inputs:
   pr-strategy:
     description: 'How to handle PRs - can be either "create" (create new PRs for each version) or "update" (keep single PR updated with latest version)'
     required: false
-    default: 'create'
+    default: 'update'
   target-branch:
     description: 'Branch to use as base for dependency updates. Defaults to repository default branch if not specified.'
     required: false


### PR DESCRIPTION
## Summary

Changes the default value for the `pr-strategy` input parameter from `create` to `update` in the updater composite action.

## Breaking Change

- **Previous behavior**: Created separate PRs for each dependency version update
- **New behavior**: Maintains a single PR that gets updated with the latest dependency version

## Migration

Users who want to preserve the previous behavior must explicitly set `pr-strategy: create`:

```yaml
- uses: getsentry/github-workflows/updater@v3
  with:
    path: path/to/dependency
    name: Dependency Name
    pr-strategy: create  # Explicitly preserve previous behavior
    api-token: ${{ secrets.GITHUB_TOKEN }}
```

## Files Changed

- `updater/action.yml`: Changed default value from 'create' to 'update'
- `updater/README.md`: Updated documentation to reflect new default
- `CHANGELOG.md`: Added breaking change entry with migration instructions

🤖 Generated with [Claude Code](https://claude.ai/code)