### PR TITLE
fix: replace literal "\n" with newlines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
   - Enables repositories to extend Danger checks without overwriting shared workflow comments
 - Sentry-CLI integration test action - Add `InvokeSentryResult::Events()` method to extract events from envelopes ([#137](https://github.com/getsentry/github-workflows/pull/137))
 
+### Fixes
+
+- Sentry-CLI integration test action - Replace literal "\n" with newlines ([#138](https://github.com/getsentry/github-workflows/pull/138))
+
 ## 3.1.0
 
 ### Features

--- a/sentry-cli/integration-test/action.psm1
+++ b/sentry-cli/integration-test/action.psm1
@@ -33,7 +33,7 @@ class InvokeSentryResult
             }
             elseif ($null -ne $envelope)
             {
-                $envelope += $_ + "\n"
+                $envelope += $_ + "`n"
             }
         }
         return $envelopes
@@ -47,7 +47,7 @@ class InvokeSentryResult
         $events = @()
         foreach ($envelope in $this.Envelopes())
         {
-            $lines = @($envelope -split "\\n")
+            $lines = @($envelope -split "`n")
             $header = $lines[0].Trim() | ConvertFrom-Json
             $eventId = $header | Select-Object -ExpandProperty event_id -ErrorAction SilentlyContinue
             if ($eventId -and $ids -notcontains $eventId)

--- a/sentry-cli/integration-test/tests/action.Tests.ps1
+++ b/sentry-cli/integration-test/tests/action.Tests.ps1
@@ -70,8 +70,8 @@ helloworld
         }
         Should -ActualValue $result.HasErrors() -BeFalse
         $result.Envelopes().Length | Should -Be 2
-        $result.Envelopes()[0].Length | Should -Be 357
-        $result.Envelopes()[1].Length | Should -Be 84
+        $result.Envelopes()[0].Length | Should -Be 352
+        $result.Envelopes()[1].Length | Should -Be 81
     }
 
     It "collects gzip compressed envelopes" {
@@ -95,7 +95,7 @@ helloworld
         
         Should -ActualValue $result.HasErrors() -BeFalse
         $result.Envelopes().Length | Should -Be 1
-        $result.Envelopes()[0].Length | Should -Be 357
+        $result.Envelopes()[0].Length | Should -Be 352
     }
 
     It "discards duplicate events" {


### PR DESCRIPTION
Splitting on literal `\\n` breaks Windows-style paths:

```json
{"debug_file":"C:\\a\\_work\\1\\s\\generated\\androidx.fragment.fragment\\obj\\Release\\net8.0-android\\Xamarin.AndroidX.Fragment.pdb"}
```
becomes `"...Release"` and `"et8.0-android..."`.