### PR TITLE
fix: drop JSON conversion for event bodies

### DIFF
--- a/sentry-cli/integration-test/action.psm1
+++ b/sentry-cli/integration-test/action.psm1
@@ -53,7 +53,7 @@ class InvokeSentryResult
             if ($eventId -and $ids -notcontains $eventId)
             {
                 $body = $lines | Select-Object -Skip 1 | Where-Object {
-                    ($_ | ConvertFrom-Json | Select-Object -ExpandProperty event_id -ErrorAction SilentlyContinue) -eq $eventId
+                    $_ -like "*`"event_id`":`"$eventId`"*"
                 } | Select-Object -First 1
                 if ($body)
                 {

--- a/sentry-cli/integration-test/tests/action.Tests.ps1
+++ b/sentry-cli/integration-test/tests/action.Tests.ps1
@@ -108,11 +108,15 @@ helloworld
 '@
             Invoke-WebRequest -Uri "$url/api/0/envelope" -Method Post -Body @'
 {"event_id":"9ec79c33ec9942ab8353589fcb2e04dc","dsn":"https://e12d836b15bb49d7bbf99e64295d995b:@sentry.io/42","sent_at":"2025-11-20T03:53:38.929Z"}
+{"type":"attachment","length":10,"content_type":"text/plain","filename":"hello.txt"}
+\xef\xbb\xbfHello\r\n
 {"type":"event","length":47,"content_type":"application/json"}
 {"event_id":"9ec79c33ec9942ab8353589fcb2e04dc"}
 '@
             Invoke-WebRequest -Uri "$url/api/0/envelope" -Method Post -Body @'
 {"event_id":"9ec79c33ec9942ab8353589fcb2e04dc","dsn":"https://e12d836b15bb49d7bbf99e64295d995b:@sentry.io/42","sent_at":"2025-11-20T03:53:41.505Z"}
+{"type":"attachment","length":10,"content_type":"text/plain","filename":"hello.txt"}
+\xef\xbb\xbfHello\r\n
 {"type":"event","length":47,"content_type":"application/json"}
 {"event_id":"9ec79c33ec9942ab8353589fcb2e04dc"}
 '@


### PR DESCRIPTION
A follow-up to #137. Drop the unnecessary JSON conversion to avoid choking on non-JSON envelope items.

#skip-changelog because #137 was not released yet