### PR TITLE
feat: support GIT_TAG with CMake variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Updater - Support CMake `GIT_TAG` with variable references like `${FOO_REF}`, resolving and updating the corresponding `set()` definition ([#149](https://github.com/getsentry/github-workflows/pull/149))
+
 ## 3.2.1
 
 ### Fixes


### PR DESCRIPTION
## Summary
- Extends `Update-CMakeFile` to handle `GIT_TAG ${VAR}` references where the actual value is defined in a `set()` call
- `Parse-CMakeFetchContent` now resolves CMake variable references to their actual values
- When updating, the `set()` line is modified instead of the `GIT_TAG` line, preserving the variable indirection
- Supports both quoted and unquoted values, hash-to-hash updates with trailing `# version` comments

## See also
- https://github.com/getsentry/sentry-playstation/issues/112
- https://github.com/getsentry/sentry-xbox/pull/15

## Test plan
- [x] Added parse tests: quoted variable, unquoted hash variable, missing variable (error), direct value (null variable)
- [x] Added update tests: tag-to-tag via variable, file structure preservation, hash update via variable
- [x] All 23 tests pass (`Invoke-Pester updater/tests/update-dependency-cmake.Tests.ps1`)