### PR TITLE
fix(validate-pr): Address review feedback

### DIFF
--- a/validate-pr/README.md
+++ b/validate-pr/README.md
@@ -7,7 +7,7 @@ Validates non-maintainer pull requests against contribution guidelines.
 1. **Validates issue references** — Non-maintainer PRs must reference a GitHub issue where the PR author and a maintainer have discussed the approach. PRs that don't meet this requirement are automatically closed with a descriptive comment.
 2. **Enforces draft status** — All PRs must start as drafts. Non-draft PRs are automatically converted and labeled.
 
-Maintainers (users with `admin` or `maintain` role) are exempt from all checks.
+Maintainers (users with `admin` or `maintain` role) are exempt from the issue reference validation. Draft enforcement applies to everyone.
 
 ## Usage
 

--- a/validate-pr/scripts/enforce-draft.js
+++ b/validate-pr/scripts/enforce-draft.js
@@ -20,12 +20,13 @@ module.exports = async ({ github, context, core }) => {
   });
 
   // Check for existing bot comment to avoid duplicates on reopen
-  const comments = await github.rest.issues.listComments({
+  const comments = await github.paginate(github.rest.issues.listComments, {
     ...repo,
     issue_number: pullRequest.number,
+    per_page: 100,
   });
-  const botComment = comments.data.find(c =>
-    c.user.type === 'Bot' &&
+  const botComment = comments.find(c =>
+    c.user?.type === 'Bot' &&
     c.body.includes('automatically converted to draft')
   );
   if (botComment) {


### PR DESCRIPTION
Follow-up to #153. Addresses review feedback from sentry[bot] and cursor[bot]:

- **Paginate comments in enforce-draft.js** — `listComments` only returns the
  first 30 results by default. PRs with many comments could get duplicate bot
  comments on reopen. Now uses `github.paginate()` consistent with
  `validate-pr.js`.
- **Null-safe user check** — guard against `c.user` being null for
  deleted/suspended GitHub accounts (`c.user?.type` instead of `c.user.type`).
- **Fix README** — clarify that maintainers are only exempt from issue reference
  validation, not draft enforcement. Draft enforcement is intentionally applied
  to everyone.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>