### PR TITLE
fix(validate-pr): Allow trusted bots to bypass validation

### DIFF
--- a/validate-pr/action.yml
+++ b/validate-pr/action.yml
@@ -37,6 +37,7 @@ runs:
     - name: Convert PR to draft
       if: >-
         steps.validate.outputs.was-closed != 'true'
+        && steps.validate.outputs.skipped != 'true'
         && github.event.pull_request.draft == false
       shell: bash
       env:
@@ -47,6 +48,7 @@ runs:
     - name: Label and comment on draft conversion
       if: >-
         steps.validate.outputs.was-closed != 'true'
+        && steps.validate.outputs.skipped != 'true'
         && github.event.pull_request.draft == false
       uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
       with:

--- a/validate-pr/scripts/validate-pr.js
+++ b/validate-pr/scripts/validate-pr.js
@@ -17,6 +17,21 @@ module.exports = async ({ github, context, core }) => {
   const prAuthor = pullRequest.user.login;
   const contributingUrl = `https://github.com/${repo.owner}/${repo.repo}/blob/${context.payload.repository.default_branch}/CONTRIBUTING.md`;
 
+  // --- Step 0: Skip allowed bots and service accounts ---
+  const ALLOWED_BOTS = [
+    'codecov-ai[bot]',
+    'dependabot[bot]',
+    'fix-it-felix-sentry[bot]',
+    'getsentry-bot',
+    'github-actions[bot]',
+    'javascript-sdk-gitflow[bot]',
+    'renovate[bot]',
+  ];
+  if (ALLOWED_BOTS.includes(prAuthor)) {
+    core.info(`PR author ${prAuthor} is an allowed bot. Skipping validation.`);
+    return;
+  }
+
   // --- Helper: check if a user has admin or maintain permission on a repo (cached) ---
   const maintainerCache = new Map();
   async function isMaintainer(owner, repoName, username) {

--- a/validate-pr/scripts/validate-pr.js
+++ b/validate-pr/scripts/validate-pr.js
@@ -28,7 +28,8 @@ module.exports = async ({ github, context, core }) => {
     'renovate[bot]',
   ];
   if (ALLOWED_BOTS.includes(prAuthor)) {
-    core.info(`PR author ${prAuthor} is an allowed bot. Skipping validation.`);
+    core.info(`PR author ${prAuthor} is an allowed bot. Skipping.`);
+    core.setOutput('skipped', 'true');
     return;
   }
 


### PR DESCRIPTION
Adds a centrally managed allowlist of trusted bots and service accounts
that are exempt from issue reference validation:

- `codecov-ai[bot]`
- `dependabot[bot]`
- `fix-it-felix-sentry[bot]`
- `getsentry-bot`
- `github-actions[bot]`
- `javascript-sdk-gitflow[bot]`
- `renovate[bot]`

Without this, bots like dependabot would have their PRs automatically
closed for not referencing a GitHub issue with maintainer discussion.

`cursor[bot]` and `Copilot` are intentionally excluded — they should
follow contribution guidelines.

#skip-changelog

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>