### PR TITLE
fix(validate-pr): Add sentry-mobile-updater to bot allowlist

### DIFF
--- a/validate-pr/scripts/validate-pr.js
+++ b/validate-pr/scripts/validate-pr.js
@@ -26,6 +26,7 @@ module.exports = async ({ github, context, core }) => {
     'github-actions[bot]',
     'javascript-sdk-gitflow[bot]',
     'renovate[bot]',
+    'sentry-mobile-updater[bot]',
   ];
   if (ALLOWED_BOTS.includes(prAuthor)) {
     core.info(`PR author ${prAuthor} is an allowed bot. Skipping.`);


### PR DESCRIPTION
Adds `sentry-mobile-updater[bot]` to the trusted bot allowlist so its
dependency update PRs aren't closed by the PR validation workflow.

Spotted via getsentry/sentry-cocoa#7755.

#skip-changelog

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>