### PR TITLE
fix(updater): Select first matching main branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 - Validate PR - Skip validation for PRs with fewer than 100 lines changed, excluding common lock files (`Cargo.lock`, `yarn.lock`, `package-lock.json`, `Pipfile.lock`, etc.). Tiny PRs no longer go through the issue-discussion loop.
 - Add validate-pr composite action for validating non-maintainer PRs against contribution guidelines ([#153](https://github.com/getsentry/github-workflows/pull/153))
 
+### Fixes
+
+- Updater - Select the first branch when multiple branches point at `HEAD` ([#165](https://github.com/getsentry/github-workflows/pull/165))
+
 ## 3.3.0
 
 ### Features

--- a/updater/scripts/update-dependency.ps1
+++ b/updater/scripts/update-dependency.ps1
@@ -162,7 +162,7 @@ if ("$Tag" -eq '') {
         if ("$headRef" -eq '') {
             throw "Couldn't determine repository head (no ref returned by ls-remote HEAD"
         }
-        $mainBranch = (git ls-remote --heads $url | Where-Object { $_.StartsWith($headRef) }) -replace '.*\srefs/heads/', ''
+        $mainBranch = (git ls-remote --heads $url | Where-Object { $_.StartsWith($headRef) } | Select-Object -First 1) -replace '.*\srefs/heads/', ''
     }
 
     $url = $url -replace '\.git$', ''

--- a/updater/tests/update-dependency.Tests.ps1
+++ b/updater/tests/update-dependency.Tests.ps1
@@ -220,7 +220,7 @@ switch ($action)
                 $output | Should -Contain 'latestTag=0.28.0'
                 $output | Should -Contain 'latestTagNice=v0.28.0'
                 $output | Should -Contain 'url=https://github.com/getsentry/sentry-cli'
-                $output | Should -Contain 'mainBranch=main master'
+                $output | Should -Contain 'mainBranch=main'
             }
         }
 

--- a/updater/tests/update-dependency.Tests.ps1
+++ b/updater/tests/update-dependency.Tests.ps1
@@ -220,7 +220,7 @@ switch ($action)
                 $output | Should -Contain 'latestTag=0.28.0'
                 $output | Should -Contain 'latestTagNice=v0.28.0'
                 $output | Should -Contain 'url=https://github.com/getsentry/sentry-cli'
-                $output | Should -Contain 'mainBranch=master'
+                $output | Should -Contain 'mainBranch=main master'
             }
         }
 


### PR DESCRIPTION
`sentry-cli` currently has `main` and `master` pointing at the same `HEAD`, so the updater started emitting both names in `mainBranch=main master` output.

```
[-] update-dependency.output.writes output 1.97s (1.96s|9ms)
 Expected 'mainBranch=master' to be found in collection @('originalTag=0', 'latestTag=0.28.0', 'latestTagNice=v0.28.0', 'url=https://github.com/getsentry/sentry-cli', 'mainBranch=main master'), but it was not found.
 at $output | Should -Contain 'mainBranch=master', /Users/jpnurmi/Projects/sentry/github-workflows/updater/tests/update-dependency.Tests.ps1:223
 at _testOutput, /Users/jpnurmi/Projects/sentry/github-workflows/updater/tests/update-dependency.Tests.ps1:223
 at <ScriptBlock>, /Users/jpnurmi/Projects/sentry/github-workflows/updater/tests/update-dependency.Tests.ps1:232
```
