### PR TITLE
test(updater): Accept either main or master as sentry-cli main branch

### DIFF
--- a/updater/tests/update-dependency.Tests.ps1
+++ b/updater/tests/update-dependency.Tests.ps1
@@ -220,7 +220,9 @@ switch ($action)
                 $output | Should -Contain 'latestTag=0.28.0'
                 $output | Should -Contain 'latestTagNice=v0.28.0'
                 $output | Should -Contain 'url=https://github.com/getsentry/sentry-cli'
-                $output | Should -Contain 'mainBranch=main'
+                # sentry-cli has both `main` and `master`; which one is reported depends on
+                # which currently points at HEAD upstream, so accept either.
+                ($output | Where-Object { $_ -like 'mainBranch=*' }) | Should -BeIn @('mainBranch=main', 'mainBranch=master')
             }
         }
 


### PR DESCRIPTION
## Summary

The `Updater @ {ubuntu,macos,windows}` jobs in **Script Tests** have been failing on `main` since [#165](https://github.com/getsentry/github-workflows/pull/165) was merged ([failing run](https://github.com/getsentry/github-workflows/actions/runs/25660187410)):

```
Expected 'mainBranch=main' to be found in collection
@('originalTag=0', 'latestTag=0.28.0', 'latestTagNice=v0.28.0',
  'url=https://github.com/getsentry/sentry-cli', 'mainBranch=master'),
but it was not found.
```

### Why it didn't fail on the PR

The test asserts against the live state of `getsentry/sentry-cli` via `git ls-remote`. At PR time (2026-05-07), both `main` and `master` of `sentry-cli` pointed at the same HEAD commit, so the SHA filter matched both refs and the new `Select-Object -First 1` returned `main` (alphabetically first). At post-merge time (2026-05-11), `sentry-cli`'s `main` and `master` no longer share a SHA — only `master` matches HEAD — so the script now emits `mainBranch=master`.

```
HEAD                660e98b...   (same as master)
refs/heads/main     54eefbd...   (different)
refs/heads/master   660e98b...
```

### Fix

Accept either `mainBranch=main` or `mainBranch=master` rather than baking transient upstream branch state into the assertion.

## Test plan

- [x] All 34 Pester tests pass locally on macOS (`Invoke-Pester` on `update-dependency.Tests.ps1`)
- [ ] Script Tests pass in CI on Ubuntu, macOS, Windows