### PR TITLE
fix(danger): harden extra-install-packages against host-shell interpolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Danger - Harden `extra-install-packages` handling: pass the package list into the container via env var instead of host-shell string interpolation (defense in depth)
+- Danger - Harden `extra-install-packages` handling: pass the package list into the container via env var instead of host-shell string interpolation (defense in depth) ([#169](https://github.com/getsentry/github-workflows/pull/169))
 
 ## 3.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Danger - Harden `extra-install-packages` handling: pass the package list into the container via env var instead of host-shell string interpolation (defense in depth)
+
 ## 3.4.0
 
 ### Features

--- a/danger/action.yml
+++ b/danger/action.yml
@@ -88,7 +88,11 @@ runs:
         EXTRA_INSTALL_PACKAGES: ${{ inputs.extra-install-packages }}
       run: |
         echo "Installing packages: $EXTRA_INSTALL_PACKAGES"
-        docker exec --user root danger sh -c "set -e && apt-get update && apt-get install -y --no-install-recommends $EXTRA_INSTALL_PACKAGES"
+        # Pass the (already-validated) package list into the container via env var and
+        # let the container's shell expand it. Single quotes prevent the host shell
+        # from interpolating the value into the command string (defense in depth).
+        docker exec --user root -e EXTRA_INSTALL_PACKAGES danger \
+          sh -c 'set -e && apt-get update && apt-get install -y --no-install-recommends $EXTRA_INSTALL_PACKAGES'
         echo "All additional packages installed successfully."
 
     - name: Run DangerJS


### PR DESCRIPTION
## Summary

Defense-in-depth hardening of the `extra-install-packages` input in the Danger action, prompted by a Sentry `container-user-root` (CWE-250) finding on `danger/action.yml:91`.

### Assessment of the Sentry finding

The finding is a **true false positive** and safe to *Agree and ignore*:

- **Root is required.** `apt-get install` needs UID 0 inside the container; the actual DangerJS run already drops to `--user $(id -u)`. CWE-250 ("unnecessary privileges") does not apply.
- **The "plausible exploit" is already blocked.** The *Validate package names* step (`danger/action.yml:40`) rejects every whitespace token not matching `^[a-z0-9][a-z0-9.+-]{0,100}$`, and the value flows via `env:` not `${{ }}`, so neither command injection nor Actions-expression injection is possible.

### What changed

Even though the injection path is already mitigated upstream, line 91 still built a command string by **host-shell-interpolating** the variable into `docker exec ... sh -c "..."` — the exact pattern #152 (VULN-1100) set out to eliminate across all actions. This PR:

- Passes the package list into the container via `docker exec -e EXTRA_INSTALL_PACKAGES`.
- Expands it inside a **single-quoted** `sh -c` body, so neither the host shell nor GitHub Actions expression evaluation ever constructs the command string.

Behavior is unchanged for valid inputs (multi-package word-splitting still happens inside the container's shell).

## Test plan

- [ ] `extra-packages-test` job in `danger-workflow-tests.yml` passes (installs `curl`, asserts availability) — exercises the modified step end-to-end.
- [ ] CHANGELOG `## Unreleased` entry added per repo convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)