### PR TITLE
ci: bump danger tests to Node.js 24

### DIFF
--- a/.github/workflows/script-tests.yml
+++ b/.github/workflows/script-tests.yml
@@ -39,7 +39,7 @@ jobs:
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: '18'
+          node-version: '24'
 
       - run: node --test
 


### PR DESCRIPTION
## Summary

Audit of CI for Node.js 20 dependence ahead of GitHub's 2026-06-02 force-migration of Node-based actions to Node.js 24.

- All four actions in this repo (`validate-pr`, `updater`, `danger`, `sentry-cli/integration-test`) are `composite` — none declare a Node runtime, so they aren't affected by the deadline.
- Third-party pinned actions (`actions/checkout@v4`, `actions/setup-node@v4`, `actions/github-script@v7`, `actions/create-github-app-token@v2`, `peter-evans/create-pull-request@v6`) currently run on `node20`; GitHub will auto-migrate them — nothing for us to do.
- The only stale Node reference was the Danger test job pinning `node-version: '18'` — Node.js 18 reached EOL in April 2025. Bumped to `24` to match the new baseline.

## Test plan

- [ ] `Script Tests / Danger JS Tests` job passes on this PR (runs `node --test` against `danger/dangerfile-utils.test.js` and syntax-checks `dangerfile.js`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)